### PR TITLE
Tweaks to utility grants page

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,22 +42,19 @@
   <li>See <a href="https://github.com/darobin/dasl.ing/issues/25">https://github.com/darobin/dasl.ing/issues/25</a> for prior discussion.</li>
   </ul>
 
-  <h3>RFP #2025-03: Emerging Data Utilities</h3>
-  <p>Recently, several new utilities and tools have emerged for working with content-addressed data (CIDs, IPLD, DASL). We welcome these new contributions to the content-addressed ecosystem! We are interested in proposals to help these emerging tools improve and mature.</p>
-  <p>The scope of work can range broadly, from technical improvements to docs, code examples, outreach, or education. This RFP is focused on active projects that show evidence of current usage and adoption (for example, more Github stars than your immediate family, a variety of issue creators, a healthy dependency graph).</p>
+  <h3>RFP #2025-03: Improving Data Utilities</h3>
+  <p>Recently, several new utilities, libraries, and tools have emerged for working with content-addressed data (CIDs, IPLD, DASL). We welcome these new contributions to the content-addressed ecosystem! We are interested in proposals to improve both longtime and emerging utilities.</p>
+  <p>The scope of work can range broadly, from technical improvements to docs, code examples, outreach, or education. This RFP is focused on active projects that show evidence of current usage and adoption (for example, Github stars, a variety of issue creators, a healthy dependency graph).</p>
 
-
-  <h2>Submission Instructions</h2>
+  <h2>How To Apply</h2>
   <h3>Submission Process</h3>
   <ol>
-  <li>Prepare your proposal according to the requirements outlined below.</li>
-  <li>Submit your proposal by completing <a href="https://docs.google.com/forms/d/e/1FAIpQLSfQXmZ-Iho7EHYwAv-j0RkEwG4xUcQRy0mtWQEyPhl4ld2jTw/viewform?usp=dialog">this form</a> no later than <strong>Sunday, March 30, 2025</strong>.</li>
+  <li>Prepare your proposal document according to the requirements outlined below.</li>
+  <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSfQXmZ-Iho7EHYwAv-j0RkEwG4xUcQRy0mtWQEyPhl4ld2jTw/viewform?usp=dialog">Submit your proposal</a> no later than <strong>Sunday, March 30, 2025</strong>.</li>
   <li>Ensure all team members are available for a potential Q&A call during the specified dates.</li>
   </ol>
 
-  <p>Thank you for your interest and good luck with your submission! For any questions, please contact <a href="mailto:utility-grants@ipfs.io">utility-grants@ipfs.io</a>.</p>
-
-  <h3>Proposal Requirements</h3>
+  <h3>Proposal Document</h3>
   <p>Please prepare a clear and concise proposal (no longer than 2 pages) with the following sections:</p>
   <ol>
   <li>Project Overview</li>
@@ -90,11 +87,22 @@
   <li>Grantee Presentations (Virtual): June 2025 (exact date TBA)</li>
   </ul>
 
+  <p>Thank you for your interest and good luck with your submission! For any questions, please contact <a href="mailto:utility-grants@ipfs.io">utility-grants@ipfs.io</a>.</p>
 
-
-
-
-  <h2>Past awardees, in alphabetic order:</h2>
+  <h2>How to Contribute</h2>
+  <p>
+    This program is supported by Protocol Labs (2022-2025) and the Filecoin Foundation (2022). If your fund or foundation aims
+    to boost open-source IPFS adoption, consider
+    <a href="mailto:implementations-grants@ipfs.io?subject=Contributing%20to%20IPFS%20Implementations%20funding">joining as a funder</a>.
+  </p>
+    
+  <h2>About</h2>
+  <p>
+    The IPFS Implementations Grants program is a cell of the <a href="https://openimpact.foundation/">Open Impact Foundation</a>,
+    a Liechtenstein charitable foundation. Our advisors are Michelle Lee, Juan Benet, and Dietrich Ayala (emeritus).
+    Thank you to Addie Wagenknecht, Matt Frehlich, and Patrick Kim.
+  </p>
+    <h2>Past awardees, in alphabetic order:</h2>
   <ul>
     <li>
       <a href="https://www.3studio.online/">3S Studio</a>, for
@@ -131,26 +139,6 @@
       <a href="https://github.com/libp2p/jvm-libp2p">jvm-libp2p</a>
     </li>
   </ul>
-  <h2>How to Apply</h2>
-  <p>
-    Make a copy of the
-    <a href="https://docs.google.com/document/d/1ca71n6iF4qxmNjF6ikBIlu8poXTvHvbs8DASHPEmDr0/edit#heading%3Dh.qu9lauf6phdl">application template</a>,
-    edit it with your proposal details, and send it to
-    <a href="mailto:implementations-grants@ipfs.io?subject=IPFS%20Implementations%20grant%20proposal%20-%20%5BPROJECT%20NAME%5D">implementations-grants@ipfs.io</a>.
-    Questions and informal inquiries are also welcome. You can expect an initial response within 2 weeks.
-  </p>
-  <h2>How to Contribute</h2>
-  <p>
-    This program is supported by Protocol Labs (2022-2025) and the Filecoin Foundation (2022). If your fund or foundation aims
-    to boost open-source IPFS adoption, consider
-    <a href="mailto:implementations-grants@ipfs.io?subject=Contributing%20to%20IPFS%20Implementations%20funding">joining as a funder</a>.
-  </p>
-  <h2>About</h2>
-  <p>
-    The IPFS Implementations Grants program is a cell of the <a href="https://openimpact.foundation/">Open Impact Foundation</a>,
-    a Liechtenstein charitable foundation. Our advisors are Michelle Lee, Juan Benet, and Dietrich Ayala (emeritus).
-    Thank you to Addie Wagenknecht, Matt Frehlich, and Patrick Kim.
-  </p>
   </main>
 </body>
 </html>


### PR DESCRIPTION
- Removes duplicate "How to Apply" section
- Moves "Past awardees" section to end, to decouple more from this Utility Grants program
- Minor cleanup of submission section