### PR TITLE
Create 2025 awardees section

### DIFF
--- a/utility-grants/index.html
+++ b/utility-grants/index.html
@@ -107,8 +107,7 @@
 
   <h2>How to Contribute</h2>
   <p>
-    This program is supported by Protocol Labs (2022-2025) and the Filecoin Foundation (2022). If your fund or foundation aims
-    to boost open-source IPFS adoption, consider
+    This program is supported by Protocol Labs (2022-2025) and the Filecoin Foundation (2022). If your fund or foundation is committed to building a more open and resilient internet, consider
     <a href="mailto:implementations-grants@ipfs.io?subject=Contributing%20to%20IPFS%20Implementations%20funding">joining as a funder</a>.
   </p>
 
@@ -116,45 +115,62 @@
   <p>
     The IPFS Implementations Grants program is a cell of the <a href="https://openimpact.foundation/">Open Impact Foundation</a>,
     a Liechtenstein charitable foundation. Our advisors are Michelle Lee, Juan Benet, and Dietrich Ayala (emeritus).
-    Thank you to Addie Wagenknecht, Matt Frehlich, and Patrick Kim.
+    Thank you to Addie Wagenknecht, Matt Frehlich, and Patrick Kim. 
   </p>
-    <h2>Past awardees, in alphabetic order:</h2>
-  <ul>
-    <li>
-      <a href="https://www.3studio.online/">3S Studio</a>, for
-      <a href="https://blog.ipfs.tech/2022-11-15-3s-studio/">IPFS plugins for the Unreal and Unity gaming engines</a>.
-    </li>
-    <li>
-      <a href="https://brave.com/">Brave Browser</a>, for
-      <a href="https://brave.com/blog/nft-pinning/">automatic NFT backups</a> to a local IPFS node.
-    </li>
-    <li>
-      <a href="https://www.igalia.com/">Igalia</a>, for
-      <a href="https://blog.ipfs.tech/14-11-2022-igalia-chromium/">refactoring Chrome to support non-HTTP protocols</a>.
-      and
-      <a href="https://blog.ipfs.tech/2021-01-15-ipfs-and-igalia-collaborate-on-dweb-in-browsers/">other</a>
-      <a href="https://blogs.igalia.com/jfernandez/2023/06/20/secure-curves-in-the-web-cryptography-api/">improvements</a>
-      across 3 major browser engines for future IPFS compatibility
-    </li>
-    <li>
-      <a href="https://fission.codes/">Fission</a>, for the
-      <a href="https://fission.codes/blog/ipvm-computation-ipfs/">IPVM content-addressed computing</a>
-      protocol and implementation
-    </li>
-    <li>
-      <a href="https://littlebearlabs.io/">Little Bear Labs</a>, for
-      <a href="https://blog.ipfs.tech/2023-05-multigateway-chromium-client/">native support for verified IPFS requests in Chromium</a>.
-    </li>
-    <li>
-      <a href="https://n0.computer/">Number Zero</a>, for <a href="https://iroh.computer/">Iroh</a>, a new
-      IPFS-based toolkit for building distributed systems
-    </li>
-    <li>
-      <a href="https://github.com/Peergos">Peergos</a>, for
-      <a href="https://github.com/Peergos/nabu">Nabu</a>, a ground-up implementation of IPFS in Java and improvements to
-      <a href="https://github.com/libp2p/jvm-libp2p">jvm-libp2p</a>
-    </li>
-  </ul>
+    <h2>Past awardees:</h2> 
+    <h3>2025 Spring:</h3>
+      <!-- could link to RFP subpage here-->
+      <ul>
+        <li>
+          <a href="https://github.com/blacksky-algorithms/rsky/tree/main/rsky-satnav">rsky-satnav CAR Explorer</a>,
+          from <a href="https://blackskyweb.xyz/">Blacksky</a>
+        </li>
+        <li>
+          <a href="https://ipfsfoundation.org/finding-your-files-in-decentralized-storage-just-got-easier/">CAR Content Locator</a>,
+          from Ben Lau, Basile Simon, and Yurko Jaremko <a href="https://blackskyweb.xyz/">Starling Lab</a>
+        </li>
+        <li>
+          <a href="https://github.com/hyphacoop/dasl-testing">DASL Test Suite</a>,
+          from Cole Anthony Capilongo, <a href="https://hypha.coop/">Hypha</a>
+        </li>
+      </ul>
+    <h3>2022-2024:</h3>
+      <ul>
+        <li>
+          <a href="https://www.3studio.online/">3S Studio</a>, for
+          <a href="https://blog.ipfs.tech/2022-11-15-3s-studio/">IPFS plugins for the Unreal and Unity gaming engines</a>.
+        </li>
+        <li>
+          <a href="https://brave.com/">Brave Browser</a>, for
+          <a href="https://brave.com/blog/nft-pinning/">automatic NFT backups</a> to a local IPFS node.
+        </li>
+        <li>
+          <a href="https://www.igalia.com/">Igalia</a>, for
+          <a href="https://blog.ipfs.tech/14-11-2022-igalia-chromium/">refactoring Chrome to support non-HTTP protocols</a>.
+          and
+          <a href="https://blog.ipfs.tech/2021-01-15-ipfs-and-igalia-collaborate-on-dweb-in-browsers/">other</a>
+          <a href="https://blogs.igalia.com/jfernandez/2023/06/20/secure-curves-in-the-web-cryptography-api/">improvements</a>
+          across 3 major browser engines for future IPFS compatibility
+        </li>
+        <li>
+          <a href="https://fission.codes/">Fission</a>, for the
+          <a href="https://fission.codes/blog/ipvm-computation-ipfs/">IPVM content-addressed computing</a>
+          protocol and implementation
+        </li>
+        <li>
+          <a href="https://littlebearlabs.io/">Little Bear Labs</a>, for
+          <a href="https://blog.ipfs.tech/2023-05-multigateway-chromium-client/">native support for verified IPFS requests in Chromium</a>.
+        </li>
+        <li>
+          <a href="https://n0.computer/">Number Zero</a>, for <a href="https://iroh.computer/">Iroh</a>, a new
+          IPFS-based toolkit for building distributed systems
+        </li>
+        <li>
+          <a href="https://github.com/Peergos">Peergos</a>, for
+          <a href="https://github.com/Peergos/nabu">Nabu</a>, a ground-up implementation of IPFS in Java and improvements to
+          <a href="https://github.com/libp2p/jvm-libp2p">jvm-libp2p</a>
+        </li>
+      </ul>
   </main>
 </body>
 </html>


### PR DESCRIPTION
- Creates a 2025 awardees section, and lists the spring & fall awardees
- Next step would be to move the Spring 2025 RFPs to their own page (edit: already done), and link that from the Awardees section for historical reference.
- This would allow us to replace the RFP info on the index page with the latest round.