### PR TITLE
List summer 2025 grantees

### DIFF
--- a/utility-grants/index.html
+++ b/utility-grants/index.html
@@ -119,8 +119,27 @@
     Thank you to Addie Wagenknecht, Matt Frehlich, and Patrick Kim. 
   </p>
     <h2>Past awardees:</h2> 
-    <h3>2025 Spring:</h3>
-      <!-- could link to RFP subpage here-->
+    <h3>2025 Summer</h3>
+      <ul>
+        <li>
+            <a href="https://github.com/hyphacoop/go-dasl">go-dasl reference library</a>,
+            from Cole Anthony Capilongo, <a href="https://hypha.coop/">Hypha</a>
+        </li>
+        <li>
+            <a href="https://crates.io/crates/dasl">dasl (Rust)</a>,
+            from <a href="https://n0.computer/">Number Zero</a>
+        </li>
+        <li>
+            <a href="https://crates.io/crates/dasl">dasl (Rust)</a>, 
+            from <a href="https://n0.computer/">Number Zero</a>
+        </li>
+        <li>
+            <a href="https://dasl.ing/bdasl.html">Big DASL (BDASL) spec w/ streaming verification<a>
+            from <a href="https://n0.computer/">Number Zero</a>
+        </li>
+      </ul>
+    <h3>2025 Spring</h3>
+      <a href="spring-2025.html">RFPs: CAR Archive Explorers and Utilities, DASL Testing, and Improving Data Utilities</a>
       <ul>
         <li>
           <a href="https://github.com/blacksky-algorithms/rsky/tree/main/rsky-satnav">rsky-satnav CAR Explorer</a>,


### PR DESCRIPTION
- Add Summer 2025 grantees
- Rename `spring-2025.html` to a general archive page where we can dump all past RFPs.